### PR TITLE
Depend on: bytestring >= 0.9.2.1

### DIFF
--- a/pipes-bytestring.cabal
+++ b/pipes-bytestring.cabal
@@ -20,7 +20,7 @@ Source-Repository head
 Library
     Build-Depends:
         base >= 4 && < 5,
-        bytestring >= 0.9 && < 0.10,
+        bytestring >= 0.9.2.1,
         transformers >= 0.2.0.0,
         pipes >= 3.0.0
     Exposed-Modules: Control.Proxy.ByteString


### PR DESCRIPTION
bytestring==0.9.2.1 seems to be the lesser version that works with GHC==7.4.1, both found in the current Haskell Platform 2012.4.0.0. 

bytestring>=0.10.0 works with GHC>=7.6.

I'm trying my late pipes-\* development on these two GHC versions. It might be nice to relax the version dependency on bytestring. I'm not aware of backwards incompatible changes between >= 0.9.2.1 versions.
