### PR TITLE
Pipes 3.1.0

### DIFF
--- a/Control/Proxy/ByteString.hs
+++ b/Control/Proxy/ByteString.hs
@@ -109,7 +109,7 @@ module Control.Proxy.ByteString (
 
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State.Strict (StateT)
-import Control.Monad.Trans.Writer.Strict (WriterT, tell)
+import Control.Monad.Trans.Writer.Lazy (WriterT, tell)
 import qualified Control.Proxy as P
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL

--- a/pipes-bytestring.cabal
+++ b/pipes-bytestring.cabal
@@ -22,6 +22,6 @@ Library
         base >= 4 && < 5,
         bytestring >= 0.9.2.1,
         transformers >= 0.2.0.0,
-        pipes >= 3.0.0
+        pipes >= 3.1.0
     Exposed-Modules: Control.Proxy.ByteString
     Default-Language: Haskell98


### PR DESCRIPTION
Dependency bump: pipes>=3.1.0

Now using lazy WriterT, after its introduction in pipes==3.1.0.
