### PR TITLE
Upgrade folds to work with pipes-3.3.0

### DIFF
--- a/pipes-bytestring.cabal
+++ b/pipes-bytestring.cabal
@@ -22,6 +22,6 @@ Library
         base >= 4 && < 5,
         bytestring >= 0.9.2.1,
         transformers >= 0.2.0.0,
-        pipes >= 3.1.0
+        pipes >= 3.3.0
     Exposed-Modules: Control.Proxy.ByteString
     Default-Language: Haskell98


### PR DESCRIPTION
This patch replaces all usages of `WriterT` with `WriterP`, and those of `StateT` with `StateP`, following the recent changes in `pipes-3.3.0`. See issue #4.

The changes are straightforward, I think that the only proxies that deserve attention are `foldlD'` and `foldrD`:

``` haskell
-- | Reduce the stream of bytes using a strict left fold
foldlD'
 :: (Monad m, P.Proxy p)
 => (s -> Word8 -> s) -> x -> StateP s p x BS.ByteString x BS.ByteString m r
foldlD' f = go where
    go x = do
        bs <- P.request x
        StateP (\s -> let s' = BS.foldl' f s bs
                      in  s' `seq` P.return_P ((), s'))
        go =<< P.respond bs

-- | Reduce the stream of bytes using a right fold
foldrD
 :: (Monad m, P.Proxy p)
 => (Word8 -> w -> w)
 -> x -> WriterP (M.Endo w) p x BS.ByteString x BS.ByteString m r
foldrD f = P.foldrD (\e w -> BS.foldr f w e)
```

We use `StateP` in `foldlD'` because we are not folding into a monoid.

I haven't tested the changes, except for some minor handcrafted tests on `foldlD'` and `foldrD`.
