### PR TITLE
Fixes DoAndIfThenElse missing

### DIFF
--- a/Pipes/ByteString.hs
+++ b/Pipes/ByteString.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE DoAndIfThenElse #-}
 
 {-| This module provides @pipes@ utilities for \"byte streams\", which are
     streams of strict 'BS.ByteString's chunks.  Use byte streams to interact


### PR DESCRIPTION
Cabal refuses to build without this although with Haskell 2010 it shouldn't matter. Probably safe to add it in anyway.
