### PR TITLE
Increase upper-bound on 'pipes-parse' to 2.2

### DIFF
--- a/pipes-bytestring.cabal
+++ b/pipes-bytestring.cabal
@@ -1,5 +1,5 @@
 Name: pipes-bytestring
-Version: 1.0.1
+Version: 1.1.0
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
 License: BSD3
@@ -21,7 +21,7 @@ Library
         base         >= 4       && < 5   ,
         bytestring   >= 0.9.2.1 && < 0.11,
         pipes        >= 4.0     && < 4.1 ,
-        pipes-parse  >= 2.0.0   && < 2.1 ,
+        pipes-parse  >= 2.0.0   && < 2.2 ,
         transformers >= 0.2.0.0 && < 0.4
     Exposed-Modules:
         Pipes.ByteString,


### PR DESCRIPTION
Confirmed to build with the `pipes-parse` version I sent a pull request for.
