### PR TITLE
Offsets for `Get` functions

### DIFF
--- a/src/Pipes/ByteString.hs
+++ b/src/Pipes/ByteString.hs
@@ -56,6 +56,7 @@ module Pipes.ByteString (
     , fromHandle
     , hGetSome
     , hGet
+    , hGetRange
 
     -- * Servers
     , hGetSomeN
@@ -238,6 +239,19 @@ hGet size h = go
                 yield bs
                 go
 {-# INLINABLE hGet #-}
+
+{-| Like 'hGet' but with an extra parameter specifying an initial handle offset
+-}
+hGetRange
+    :: MonadIO m
+    => Int -- ^ Offset
+    -> Int -- ^ Size
+    -> IO.Handle
+    -> Producer' ByteString m ()
+hGetRange offset size h = do
+    liftIO $ IO.hSeek h IO.AbsoluteSeek (fromIntegral offset)
+    hGet size h
+{-# INLINABLE hGetRange #-}
 
 (^.) :: a -> ((b -> Constant b b) -> (a -> Constant b a)) -> b
 a ^. lens = getConstant (lens Constant a)


### PR DESCRIPTION
I was porting some `conduit` code to `pipes` when I stepped into [sourceHandleRange](http://hackage.haskell.org/package/conduit-1.0.17.1/docs/Data-Conduit-Binary.html#v:sourceHandleRange) which doesn't have an equivalent in `pipes-bytestring`.

If you like having these `...Range` functions in `pipes-bytestring` I could add the rest of them to this pull request (`hGetSomeRange`, `hGetRangeN`...). Otherwise, I can easily define those functions directly where I need them, so it's not a big issue for me not having them in `pipes-bytestring`.
