### PR TITLE
Bump upper bounds for `transformers` dependency

### DIFF
--- a/pipes-bytestring.cabal
+++ b/pipes-bytestring.cabal
@@ -24,6 +24,6 @@ Library
         pipes-group  >= 1.0.0   && < 1.1 ,
         pipes-parse  >= 3.0.0   && < 3.1 ,
         profunctors  >= 3.1.1   && < 4.1 ,
-        transformers >= 0.2.0.0 && < 0.4
+        transformers >= 0.2.0.0 && < 0.5
     Exposed-Modules: Pipes.ByteString
     GHC-Options: -O2 -Wall


### PR DESCRIPTION
This only includes the `transformers` dependency bump. It doesn't include the `fromBuild` changes in the previous #37 request.
