### PR TITLE
Add `fromBuilder` to convert a `Builder` into a `Producer` of `ByteString`s

### DIFF
--- a/pipes-bytestring.cabal
+++ b/pipes-bytestring.cabal
@@ -18,12 +18,12 @@ Source-Repository head
 Library
     Hs-Source-Dirs: src
     Build-Depends:
-        base         >= 4       && < 5   ,
-        bytestring   >= 0.9.2.1 && < 0.11,
-        pipes        >= 4.0     && < 4.2 ,
-        pipes-group  >= 1.0.0   && < 1.1 ,
-        pipes-parse  >= 3.0.0   && < 3.1 ,
-        profunctors  >= 3.1.1   && < 4.1 ,
-        transformers >= 0.2.0.0 && < 0.4
+        base         >= 4        && < 5   ,
+        bytestring   >= 0.10.2.0 && < 0.11,
+        pipes        >= 4.0      && < 4.2 ,
+        pipes-group  >= 1.0.0    && < 1.1 ,
+        pipes-parse  >= 3.0.0    && < 3.1 ,
+        profunctors  >= 3.1.1    && < 4.1 ,
+        transformers >= 0.2.0.0  && < 0.4
     Exposed-Modules: Pipes.ByteString
     GHC-Options: -O2 -Wall

--- a/src/Pipes/ByteString.hs
+++ b/src/Pipes/ByteString.hs
@@ -54,6 +54,7 @@ module Pipes.ByteString (
       fromLazy
     , stdin
     , fromHandle
+    , fromBuilder
     , hGetSome
     , hGet
     , hGetRange
@@ -146,6 +147,7 @@ import qualified Data.ByteString as BS
 import Data.ByteString (ByteString)
 import Data.ByteString.Internal (isSpaceWord8)
 import qualified Data.ByteString.Lazy as BL
+import Data.ByteString.Builder (Builder, toLazyByteString)
 import Data.ByteString.Lazy.Internal (foldrChunks, defaultChunkSize)
 import Data.ByteString.Unsafe (unsafeTake, unsafeDrop)
 import Data.Char (ord)
@@ -205,6 +207,11 @@ fromHandle :: MonadIO m => IO.Handle -> Producer' ByteString m ()
 fromHandle = hGetSome defaultChunkSize
 -- TODO: Test chunk size for performance
 {-# INLINABLE fromHandle #-}
+
+-- | Convert a 'Builder' into a 'Producer' of strict 'ByteString's
+fromBuilder :: Monad m => Builder -> Producer' ByteString m ()
+fromBuilder = fromLazy . toLazyByteString
+{-# INLINABLE fromBuilder #-}
 
 {-| Convert a handle into a byte stream using a maximum chunk size
 


### PR DESCRIPTION
This corresponds to the previous #37 request without the `transfomers` update changes.
