### PR TITLE
support GHC 9.0

### DIFF
--- a/pipes-bytestring.cabal
+++ b/pipes-bytestring.cabal
@@ -19,7 +19,7 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base         >= 4       && < 5   ,
-        bytestring   >= 0.9.2.1 && < 0.11,
+        bytestring   >= 0.9.2.1 && < 0.12,
         pipes        >= 4.0     && < 4.4 ,
         pipes-group  >= 1.0.0   && < 1.1 ,
         pipes-parse  >= 3.0.0   && < 3.1 ,

--- a/src/Pipes/ByteString.hs
+++ b/src/Pipes/ByteString.hs
@@ -284,7 +284,7 @@ a ^. lens = getConstant (lens Constant a)
 {-| Like 'hGetSome', except you can vary the maximum chunk size for each request
 -}
 hGetSomeN :: MonadIO m => IO.Handle -> Int -> Server' Int ByteString m ()
-hGetSomeN h = go
+hGetSomeN h size = go size
   where
     go size = do
         bs <- liftIO (BS.hGetSome h size)
@@ -297,7 +297,7 @@ hGetSomeN h = go
 
 -- | Like 'hGet', except you can vary the chunk size for each request
 hGetN :: MonadIO m => IO.Handle -> Int -> Server' Int ByteString m ()
-hGetN h = go
+hGetN h size = go size
   where
     go size = do
         bs <- liftIO (BS.hGet h size)


### PR DESCRIPTION
depends on Gabriel439/Haskell-Pipes-Parse-Library#43

two trivial changes due to [simplified subsumption](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#simplified-subsumption)

Tested locally with `cabal build` with this `cabal.project.local`:
```
with-compiler: ghc-9.0.1
allow-newer: hashable:base
source-repository-package
  type: git
  location: https://github.com/amesgen/Haskell-Pipes-Parse-Library
  tag: c311edc6ba35c1936bb4d9b50ffec9b08e238c3c
```