### PR TITLE
Allow bytestring-0.12

### DIFF
--- a/pipes-bytestring.cabal
+++ b/pipes-bytestring.cabal
@@ -19,7 +19,7 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base         >= 4       && < 5   ,
-        bytestring   >= 0.9.2.1 && < 0.12,
+        bytestring   >= 0.9.2.1 && < 0.13,
         pipes        >= 4.0     && < 4.4 ,
         pipes-group  >= 1.0.0   && < 1.1 ,
         pipes-parse  >= 3.0.0   && < 3.1 ,


### PR DESCRIPTION
Fixes #55.

Tested using

```
cabal build -c 'bytestring>=0.12' -w ghc-9.8.1
```
